### PR TITLE
Add the map function to the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -43,4 +43,14 @@ describe('_.map', () => {
 
         expect(_.map(input, inputMapper)).toEqual(expectedOutput);
     });
+
+    test('maps every item in the provided array based on its index', () => {
+        let input = ['', '', '', '', ''];
+        let mapperInput = (value, index) => {
+            return index;
+        }
+        let expectedOutput = [0, 1, 2, 3, 4];
+
+        expect(_.map(input, mapperInput)).toEqual(expectedOutput);
+    });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,16 +1,20 @@
-const { _ } = require('higher-order-.js');
+const { _ } = require('../higher-order.js');
 
 describe('_.map', () => {
-    test('maps an empty array and returns an empty array object', () => {
-
-    });
-
     test('throws a typeError if the provided object to be mapped isn\'t an array', () => {
 
     });
 
     test('throws a typeError if the provided mapper isn\'t a function value', () => {
 
+    });
+
+    test('maps an empty array and returns an empty array object', () => {
+        let input = [];
+        let inputMapper = () => {};
+        let expectedOutput = [];
+
+        expect(_.map(input, inputMapper)).toEqual(expectedOutput);
     });
 
     test('maps every item in the provided array and returns the mapped output', () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,8 +1,19 @@
 const { _ } = require('higher-order-.js');
 
 describe('_.map', () => {
-    test('it maps every item in the provided array and returns the mapped output', () => {
+    test('maps an empty array and returns an empty array object', () => {
+
+    });
+
+    test('throws a typeError if the provided object to be mapped isn\'t an array', () => {
+
+    });
+
+    test('throws a typeError if the provided mapper isn\'t a function value', () => {
+
+    });
+
+    test('maps every item in the provided array and returns the mapped output', () => {
 
     });
 });
-

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -28,6 +28,19 @@ describe('_.map', () => {
     });
 
     test('maps every item in the provided array and returns the mapped output', () => {
+        let input = [0, 1, 2, 3, 4, 5];
+        let inputMapper = (value) => {
+            let textBarUnit = '#';
+            let textBar = ''
 
+            for (let i = 0; i < value; i++) {
+                textBar += textBarUnit;
+            }
+
+            return textBar;
+        }
+        let expectedOutput = ['', '#', '##', '###', '####', '#####'];
+
+        expect(_.map(input, inputMapper)).toEqual(expectedOutput);
     });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -2,11 +2,21 @@ const { _ } = require('../higher-order.js');
 
 describe('_.map', () => {
     test('throws a typeError if the provided object to be mapped isn\'t an array', () => {
+        let input = null;
+        let inputMapper = null;
 
+        expect(() => {
+            _.map(input, inputMapper);
+        }).toThrow();
     });
 
     test('throws a typeError if the provided mapper isn\'t a function value', () => {
+        let input = [];
+        let inputMapper = null;
 
+        expect(() => {
+            _.map(input, inputMapper);
+        }).toThrow();
     });
 
     test('maps an empty array and returns an empty array object', () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -44,12 +44,29 @@ describe('_.map', () => {
         expect(_.map(input, inputMapper)).toEqual(expectedOutput);
     });
 
-    test('maps every item in the provided array based on its index', () => {
+    test('map passes the current value index as the second argument to the mapper closure', () => {
         let input = ['', '', '', '', ''];
         let mapperInput = (value, index) => {
             return index;
         }
         let expectedOutput = [0, 1, 2, 3, 4];
+
+        expect(_.map(input, mapperInput)).toEqual(expectedOutput);
+    });
+
+    test('map passes the source array as the last argument to the mapper closure', () => {
+        let input = [0, 1, 2, 3, 4, 5, 6];
+        let mapperInput = (value, index, arr) => {
+            switch (index) {
+                case 0:
+                    return '*';
+                case arr.length - 1:
+                    return '*';
+                default:
+                    return value;
+            }
+        }
+        let expectedOutput = ['*', 1, 2, 3, 4, 5, '*'];
 
         expect(_.map(input, mapperInput)).toEqual(expectedOutput);
     });

--- a/higher-order.js
+++ b/higher-order.js
@@ -20,7 +20,9 @@ const _ = {
 
         let mapped = [];
 
-        // ...
+        for (let i = 0; i < arr.length; i++) {
+            mapped.push(mapper(arr[i]));
+        }
 
         return mapped;
     }

--- a/higher-order.js
+++ b/higher-order.js
@@ -21,7 +21,7 @@ const _ = {
         let mapped = [];
 
         for (let i = 0; i < arr.length; i++) {
-            mapped.push(mapper(arr[i], i));
+            mapped.push(mapper(arr[i], i, arr));
         }
 
         return mapped;

--- a/higher-order.js
+++ b/higher-order.js
@@ -21,7 +21,7 @@ const _ = {
         let mapped = [];
 
         for (let i = 0; i < arr.length; i++) {
-            mapped.push(mapper(arr[i]));
+            mapped.push(mapper(arr[i], i));
         }
 
         return mapped;

--- a/higher-order.js
+++ b/higher-order.js
@@ -3,7 +3,15 @@
  * The root object of the library containing the higher-order functions.
  */
 const _ = {
-
+    /**
+     * Given an array and a mapper closure, returns a transformed array based the mapper being applied to each original array elements.
+     * @param {Array} arr - The array to be mapped into another array of mapped values. 
+     * @param {Function} mapper - The function being applied to map each value of the original array.
+     * @returns {Array} mappedArray - The mapped array.
+     */
+    map: function(arr, mapper) {
+        return [];
+    }
 }
 
 module.exports = { _ };

--- a/higher-order.js
+++ b/higher-order.js
@@ -10,7 +10,19 @@ const _ = {
      * @returns {Array} mappedArray - The mapped array.
      */
     map: function(arr, mapper) {
-        return [];
+        if (typeof arr != 'object' || !Array.isArray(arr)) {
+            throw new TypeError('The passed array to be mapped must be a valid one.');
+        }
+
+        if (typeof mapper != 'function') {
+            throw new TypeError('The passed mapper closure must be a valid one.');
+        }
+
+        let mapped = [];
+
+        // ...
+
+        return mapped;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "name": "higher-order",
     "main": "higher-order.js",
+    "devDependencies": {
+        "jest": "^24.5.0"
+    },
     "scripts" : {
         "start": "node higher-order.js",
         "test": "jest"


### PR DESCRIPTION
Adds the `map` higher-order function to the library.

Example usage: `let output = _.map(arr, (value, index, arr) => { /*...*/ };`