### PR TITLE
Add the reduce function to the library

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -90,10 +90,19 @@ describe('_.reduce', () => {
     });
 
     test('returns the initial value if the passed array is empty', () => {
+        const input = [];
+        const reducerInput = () => {};
+        const initialValueInput = 'this should be returned.';
 
+        expect(_.reduce(input, reducerInput, initialValueInput)).toEqual(initialValueInput);
     });
 
     test('throws an error if no initial value is passed and the array to reduce is empty', () => {
-
+        const input = [];
+        const reducerInput = () => {};
+        
+        expect(() => {
+            _.reduce(input, reducerInput);
+        }).toThrow();
     });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -46,7 +46,7 @@ describe('_.map', () => {
 
     test('map passes the current value index as the second argument to the mapper closure', () => {
         const input = ['', '', '', '', ''];
-        const mapperInput = (value, index) => index;
+        const mapperInput = (_value, index) => index;
         const expectedOutput = [0, 1, 2, 3, 4];
 
         expect(_.map(input, mapperInput)).toEqual(expectedOutput);

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -71,3 +71,21 @@ describe('_.map', () => {
         expect(_.map(input, mapperInput)).toEqual(expectedOutput);
     });
 });
+
+describe('_.reduce', () => {
+    test('throws an error if the passed array isn\'t a valid one', () => {
+
+    });
+
+    test('throws an error if the passed reducer isn\'t a valid function', () => {
+
+    });
+
+    test('returns the initial value if the passed array is empty', () => {
+
+    });
+
+    test('throws an error if no initial value is passed and the array to reduce is empty', () => {
+
+    });
+});

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -113,4 +113,23 @@ describe('_.reduce', () => {
 
         expect(_.reduce(input, reducerInput)).toEqual(expectedOutput);
     });
+
+    test('reduce passes the index argument into the reducer callback', () => {
+        const input = [0, 1, 2, 3];
+        const reducerInput = (previous, current, index) => previous + (current * index);
+        const expectedOutput = 14;
+
+        expect(_.reduce(input, reducerInput)).toEqual(expectedOutput);
+    });
+
+    test('reduce passes the array argument into the reducer callback', () => {
+        const input = [0, 1, 2, 3];
+        const reducerInput = (previous, current, index, array) => {
+            // Sum only the values between the beginning and end of the array. 
+            return (index == 0 || index == array.length - 1) ? previous : previous + current;
+        };
+        const expectedOutput = 3;
+
+        expect(_.reduce(input, reducerInput)).toEqual(expectedOutput);
+    });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -72,11 +72,21 @@ describe('_.map', () => {
 
 describe('_.reduce', () => {
     test('throws an error if the passed array isn\'t a valid one', () => {
+        const input = null;
+        const reducerInput = (previous, current) => previous + current;
 
+        expect(() => {
+            _.reduce(input, reducerInput);
+        }).toThrow();
     });
 
     test('throws an error if the passed reducer isn\'t a valid function', () => {
+        const input = [0, 1, 2, 3, 4, 5];
+        const reducerInput = null;
 
+        expect(() => {
+            _.reduce(input, reducerInput);
+        }).toThrow();
     });
 
     test('returns the initial value if the passed array is empty', () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -105,4 +105,12 @@ describe('_.reduce', () => {
             _.reduce(input, reducerInput);
         }).toThrow();
     });
+
+    test('reduces an array into a value',() => {
+        const input = [0, 1, 2, 3, 4, 5];
+        const reducerInput = (previous, current) => previous + current;
+        const expectedOutput = 15;
+
+        expect(_.reduce(input, reducerInput)).toEqual(expectedOutput);
+    });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -132,4 +132,21 @@ describe('_.reduce', () => {
 
         expect(_.reduce(input, reducerInput)).toEqual(expectedOutput);
     });
+
+    test('reduce passes the 1st and 2nd array values to the reducer in the first run, if the initial value is null', () => {
+        const input = [5, 6, 7, 8];
+        const reducerInput = (previous, current) => previous + current;
+        const expectedOutput = 26;
+
+        expect(_.reduce(input, reducerInput)).toEqual(expectedOutput);
+    });
+
+    test('reduce passes the initial value and the 1st array value to the reducer in the first run, if the initial value is provided', () => {
+        const input = [5, 6, 7, 8];
+        const reducerInput = (previous, current) => previous + current;
+        const initialValueInput = 4;
+        const expectedOutput = 30;
+
+        expect(_.reduce(input, reducerInput, initialValueInput)).toEqual(expectedOutput);
+    });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -2,8 +2,8 @@ const { _ } = require('../higher-order.js');
 
 describe('_.map', () => {
     test('throws a typeError if the provided object to be mapped isn\'t an array', () => {
-        let input = null;
-        let inputMapper = null;
+        const input = null;
+        const inputMapper = null;
 
         expect(() => {
             _.map(input, inputMapper);
@@ -11,8 +11,8 @@ describe('_.map', () => {
     });
 
     test('throws a typeError if the provided mapper isn\'t a function value', () => {
-        let input = [];
-        let inputMapper = null;
+        const input = [];
+        const inputMapper = null;
 
         expect(() => {
             _.map(input, inputMapper);
@@ -20,17 +20,17 @@ describe('_.map', () => {
     });
 
     test('maps an empty array and returns an empty array object', () => {
-        let input = [];
-        let inputMapper = () => {};
-        let expectedOutput = [];
+        const input = [];
+        const inputMapper = () => {};
+        const expectedOutput = [];
 
         expect(_.map(input, inputMapper)).toEqual(expectedOutput);
     });
 
     test('maps every item in the provided array and returns the mapped output', () => {
-        let input = [0, 1, 2, 3, 4, 5];
-        let inputMapper = (value) => {
-            let textBarUnit = '#';
+        const input = [0, 1, 2, 3, 4, 5];
+        const inputMapper = (value) => {
+            const textBarUnit = '#';
             let textBar = ''
 
             for (let i = 0; i < value; i++) {
@@ -39,24 +39,22 @@ describe('_.map', () => {
 
             return textBar;
         }
-        let expectedOutput = ['', '#', '##', '###', '####', '#####'];
+        const expectedOutput = ['', '#', '##', '###', '####', '#####'];
 
         expect(_.map(input, inputMapper)).toEqual(expectedOutput);
     });
 
     test('map passes the current value index as the second argument to the mapper closure', () => {
-        let input = ['', '', '', '', ''];
-        let mapperInput = (value, index) => {
-            return index;
-        }
-        let expectedOutput = [0, 1, 2, 3, 4];
+        const input = ['', '', '', '', ''];
+        const mapperInput = (value, index) => index;
+        const expectedOutput = [0, 1, 2, 3, 4];
 
         expect(_.map(input, mapperInput)).toEqual(expectedOutput);
     });
 
     test('map passes the source array as the last argument to the mapper closure', () => {
-        let input = [0, 1, 2, 3, 4, 5, 6];
-        let mapperInput = (value, index, arr) => {
+        const input = [0, 1, 2, 3, 4, 5, 6];
+        const mapperInput = (value, index, arr) => {
             switch (index) {
                 case 0:
                     return '*';
@@ -66,7 +64,7 @@ describe('_.map', () => {
                     return value;
             }
         }
-        let expectedOutput = ['*', 1, 2, 3, 4, 5, '*'];
+        const expectedOutput = ['*', 1, 2, 3, 4, 5, '*'];
 
         expect(_.map(input, mapperInput)).toEqual(expectedOutput);
     });

--- a/higher-order.js
+++ b/higher-order.js
@@ -58,13 +58,10 @@ const _ = {
             throw new TypeError('The passed mapper closure must be a valid one.');
         }
 
-        let mapped = [];
-
-        for (let i = 0; i < arr.length; i++) {
-            mapped.push(mapper(arr[i], i, arr));
-        }
-
-        return mapped;
+        return this.reduce(arr, (previous, current, index, array) => {
+            previous.push(mapper(current, index, array));
+            return previous;
+        }, []);
     }
 }
 

--- a/higher-order.js
+++ b/higher-order.js
@@ -18,6 +18,16 @@ const _ = {
         if (typeof reducer != 'function') {
             throw new TypeError('The passed reducer argument must be avalid function.');
         }
+
+        let result = initialValue || arr[0];
+
+        if (!result) {
+            throw new Error('If the passed array argument is empty, an initial value argument must be provided.');
+        }
+
+        // TODO...
+
+        return result;
     },
 
     /**

--- a/higher-order.js
+++ b/higher-order.js
@@ -4,6 +4,17 @@
  */
 const _ = {
     /**
+     * Given an array and a reducer function, returns the single value from calling 
+     * reducer on each element of the array and accumulating the result.
+     * @param {Array} arr 
+     * @param {Function} reducer 
+     * @param {Any} initialValue 
+     */
+    reduce: function(arr, reducer, initialValue) {
+
+    },
+
+    /**
      * Given an array and a mapper closure, returns a transformed array based the mapper being applied to each original array elements.
      * @param {Array} arr - The array to be mapped into another array of mapped values. 
      * @param {Function} mapper - The function being applied to map each value of the original array.

--- a/higher-order.js
+++ b/higher-order.js
@@ -19,13 +19,24 @@ const _ = {
             throw new TypeError('The passed reducer argument must be avalid function.');
         }
 
-        let result = initialValue || arr[0];
-
-        if (arr.length == 0 && !result) {
+        if (arr.length == 0 && !initialValue) {
             throw new Error('If the passed array argument is empty, an initial value argument must be provided.');
         }
 
-        for (let i = 0; i < arr.length; i++) {
+        // If there's an initial value, the current value to reduce should be the first array value.
+        let i = 0
+        let result;
+
+        // If there's an initial value, it's used in the reduction, and reduce start at 0.
+        if (initialValue) {
+            result = initialValue;
+        } else {
+            // Otherwise, reduce uses the two first arguments as values:
+            i = 1;
+            result = arr[0];
+        }
+
+        for (; i < arr.length; i++) {
             result = reducer(result, arr[i], i, arr);
         }
 

--- a/higher-order.js
+++ b/higher-order.js
@@ -26,7 +26,7 @@ const _ = {
         }
 
         for (let i = 0; i < arr.length; i++) {
-            result = reducer(result, arr[i]);
+            result = reducer(result, arr[i], i, arr);
         }
 
         return result;

--- a/higher-order.js
+++ b/higher-order.js
@@ -21,11 +21,13 @@ const _ = {
 
         let result = initialValue || arr[0];
 
-        if (!result) {
+        if (arr.length == 0 && !result) {
             throw new Error('If the passed array argument is empty, an initial value argument must be provided.');
         }
 
-        // TODO...
+        for (let i = 0; i < arr.length; i++) {
+            result = reducer(result, arr[i]);
+        }
 
         return result;
     },

--- a/higher-order.js
+++ b/higher-order.js
@@ -11,7 +11,13 @@ const _ = {
      * @param {Any} initialValue 
      */
     reduce: function(arr, reducer, initialValue) {
+        if (typeof arr != 'object' || !(arr instanceof Array)) {
+            throw new TypeError('The passed array argument must be a valid one.');
+        }
 
+        if (typeof reducer != 'function') {
+            throw new TypeError('The passed reducer argument must be avalid function.');
+        }
     },
 
     /**


### PR DESCRIPTION
This PR adds the `reduce` function to the library, making it possible to reduce an array into only one value, by applying the passed `reducer` callback closure to each array value and returning the result of the operation.

Example usage: `_.reduce(array, (previous, current, index, array) => { return calculatedValue; }, optionalInitialValue);`

The `map` function is also implement to use reduce (by supplying an initial array, then pushing into it, and returning it as the accumulated value) instead of iterating. 