### PR TITLE
Add reject to the library

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -169,6 +169,25 @@ describe('_.filter', () => {
     });
 });
 
+describe('_.reject', () => {
+    test('throws an error if the rejection applier is not a valid function.', () => {
+        expect(() => _.reject([1], null)).toThrow(TypeError);
+    });
+
+    test('returns an empty array if an empty one is passed', () => {
+        const input = [];
+        const rejectionApplier = x => true;
+        expect(_.reject(input, rejectionApplier)).toEqual([]);
+    });
+
+    test('filters the passed array based on the passed rejection closure.', () => {
+        const input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        const rejectionApplier = x => x > 5;
+
+        expect(_.reject(input, rejectionApplier)).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+});
+
 describe('_.all', () => {
     test('returns false if the array is empty.', () => {
         expect(_.all([], (element) => true)).toEqual(false);

--- a/higher-order.js
+++ b/higher-order.js
@@ -96,6 +96,16 @@ const _ = {
     },
 
     /**
+     * Given an array and filter, returns a new array with elements of the original array that don't apply to the rejection closure.
+     * @param {Array} arr - The array to be filtered.
+     * @param {Function} rejectionApplier - The function in charge of deciding if a value should be included in the filtered array.
+     * @returns {Array} filteredArray - The filtered array.
+     */
+    reject: function(arr, rejectionApplier) {
+    
+    },
+
+    /**
      * Given an array and a function, runs the given function on every element and returns true if all elements are accounted.
      * @param {Array} arr - The array to be checked.
      * @param {Function} accounter - The function in charge of checking if a value should be considered.

--- a/higher-order.js
+++ b/higher-order.js
@@ -102,7 +102,7 @@ const _ = {
      * @returns {Array} filteredArray - The filtered array.
      */
     reject: function(arr, rejectionApplier) {
-    
+        return this.filter(arr, (val) => !rejectionApplier(val));
     },
 
     /**


### PR DESCRIPTION
Adds the `reject()` function to the library. Reject works by returning a new array with all the original values, except the rejected ones.

Example usage: `_.reject([0, 1, 2, 3, 4, 5], (val) => val > 3);`