### PR TITLE
Add maxBy() and minBy() functions

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { _ } = require('../higher-order.js');
 
 describe('_.reduce', () => {
@@ -249,7 +251,17 @@ describe('_.min', () => {
 });
 
 describe('_.maxBy', () => {
-    
+    test('throws an error if the array is not a valid one.', () => {
+        expect(() => _.maxBy(null)).toThrow(TypeError);
+    });
+
+    test('throws an error if the comparator function isn\'t valid.', () => {
+        expect(() => _.maxBy([1, 2], null)).toThrow(TypeError);
+    });
+
+    test('returns undefined if an empty array is passed.', () => {
+        expect(_.maxBy([], () => true)).toEqual(undefined);
+    });
 });
 
 describe('_.all', () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -262,6 +262,10 @@ describe('_.maxBy', () => {
     test('returns undefined if an empty array is passed.', () => {
         expect(_.maxBy([], () => true)).toEqual(undefined);
     });
+
+    test('returns the maximum value from the array by using the iteratee.', () => {
+        expect(_.maxBy([{val: 120}, {val: 121}, {val: 20}], element => element.val)).toEqual(121)
+    });
 });
 
 describe('_.all', () => {
@@ -315,7 +319,7 @@ describe('_.any', () => {
 
     test('returns true if any element is accounted', () => {
         const input = [5, 6, 7, 8, 9, 10];
-        const accounterInput = (element) => element == 10;
+        const accounterInput = (element) => element === 10;
 
         expect(_.any(input, accounterInput)).toEqual(true);
     });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -248,6 +248,10 @@ describe('_.min', () => {
     });
 });
 
+describe('_.maxBy', () => {
+    
+});
+
 describe('_.all', () => {
     test('returns false if the array is empty.', () => {
         expect(_.all([], (element) => true)).toEqual(false);

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -263,8 +263,26 @@ describe('_.maxBy', () => {
         expect(_.maxBy([], () => true)).toEqual(undefined);
     });
 
-    test('returns the maximum value from the array by using the iteratee.', () => {
-        expect(_.maxBy([{val: 120}, {val: 121}, {val: 20}], element => element.val)).toEqual(121)
+    test('returns the maximum value from the array by using the closure.', () => {
+        expect(_.maxBy([{val: 120}, {val: 121}, {val: 20}], element => element.val)).toEqual(121);
+    });
+});
+
+describe('_.minBy', () => {
+    test('throws an error if the array is not a valid one.', () => {
+        expect(() => _.minBy(null)).toThrow(TypeError);
+    });
+
+    test('throws an error if the comparator function isn\'t valid.', () => {
+        expect(() => _.minBy([1, 2], null)).toThrow(TypeError);
+    });
+
+    test('returns undefined if an empty array is passed.', () => {
+        expect(_.minBy([], () => true)).toEqual(undefined);
+    });
+
+    test('returns the minimum value from the array by using the closure.', () => {
+        expect(_.minBy([{val: 120}, {val: 121}, {val: 20}], element => element.val)).toEqual(20);
     });
 });
 

--- a/higher-order.js
+++ b/higher-order.js
@@ -135,7 +135,12 @@ const _ = {
      * @param {Function} comparator - the closure in charge of returning the largest of two elements.
      */
     maxBy: function(arr, comparator) {
-        
+        guardArray(arr);
+        guardFunction(comparator);
+
+        if (arr.length === 0) {
+            return undefined;
+        }
     },
 
     /**

--- a/higher-order.js
+++ b/higher-order.js
@@ -134,9 +134,10 @@ const _ = {
     },
 
     /**
-     * Given an array and an closure, runs the closure in each element and returns the criterion by which the element is ranked.
+     * Given an array and a closure, runs the closure in each element and returns the criterion by which the element is 
+     * ranked as the maximum value.
      * @param {Array} arr - the array with the elements to be compared.
-     * @param {Function} callback - the function in charge of returning the criterion by which the element is ranked.
+     * @param {Function} callback - the function in charge of returning the criterion by which the element is ranked as the maximum value.
      */
     maxBy: function(arr, callback) {
         guardFunction(callback);
@@ -145,10 +146,23 @@ const _ = {
             return undefined;
         }
 
-        return this.reduce(arr, (previous, current) => {
-            const currentValue = callback(current);
-            return previous > currentValue ? previous : currentValue; 
-        });
+        return this.reduce(arr, (previous, current) => this.max([previous, callback(current)]));
+    },
+
+    /**
+     * Given an array and a closure, runs the closure in each element and returns the criterion by which the element is 
+     * ranked as the minimum value.
+     * @param {Array} arr - the array with the elements to be compared.
+     * @param {Function} callback - the function in charge of returning the criterion by which the element is ranked as the minimum value.
+     */
+    minBy: function(arr, callback) {
+        guardFunction(callback);
+
+        if (arr.length === 0) {
+            return undefined;
+        }
+
+        return this.reduce(arr, (previous, current) => this.min([previous, callback(current)]));
     },
 
     /**

--- a/higher-order.js
+++ b/higher-order.js
@@ -130,17 +130,21 @@ const _ = {
     },
 
     /**
-     * Given an array, runs comparator with all elements and returns the largest returned from it.
+     * Given an array and an iteratee closure, runs iteratee in each element and returns the criterion by which the element is ranked.
      * @param {Array} arr - the array with the elements to be compared.
-     * @param {Function} comparator - the closure in charge of returning the largest of two elements.
+     * @param {Function} iteratee - the closure in charge of returning the criterion by which the element is ranked.
      */
-    maxBy: function(arr, comparator) {
-        guardArray(arr);
-        guardFunction(comparator);
+    maxBy: function(arr, iteratee) {
+        guardFunction(iteratee);
 
         if (arr.length === 0) {
             return undefined;
         }
+
+        return this.reduce(arr, (previous, current) => {
+            const currentValue = iteratee(current);
+            return previous > currentValue ? previous : currentValue; 
+        });
     },
 
     /**

--- a/higher-order.js
+++ b/higher-order.js
@@ -130,6 +130,15 @@ const _ = {
     },
 
     /**
+     * Given an array, runs comparator with all elements and returns the largest returned from it.
+     * @param {Array} arr - the array with the elements to be compared.
+     * @param {Function} comparator - the closure in charge of returning the largest of two elements.
+     */
+    maxBy: function(arr, comparator) {
+        
+    },
+
+    /**
      * Given an array and a function, runs the given function on every element and returns true if all elements are accounted.
      * @param {Array} arr - The array to be checked.
      * @param {Function} accounter - The function in charge of checking if a value should be considered.


### PR DESCRIPTION
Adds the `maxBy` and `minBy` functions to the library. These functions return the value by which the ranking should take place.

Example usage: `maxBy([{a: 12}, {a: 13}, {a: 2}], (val) => val.a)`