### PR TITLE
Implement flow to compose functions passed in an array

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -456,3 +456,36 @@ describe('_.sort', () => {
         expect(_.sort([false, true, false])).toEqual([false, false, true]);
     });
 });
+
+describe('_.flow', () => {
+    test('throws an error if the functions array is not valid', () => {
+        expect(() => _.flow(null)).toThrow(TypeError);
+    });
+
+    test('Returns a closure when called', () => {
+        expect(_.flow([])).toEqual(expect.any(Function));
+    });
+
+    test('Returns a closure that calls the single passed function', () => {
+        const single = _.flow([val => val]);
+        expect(single('val')).toBe('val');
+    });
+
+    test('Returns a closure that calls the two functions in order, by passing the results of one call into the other', () => {
+        const add = (a, b) => a + b;
+        const square = n => n * n;
+        const composed = _.flow([add, square]);
+
+        expect(composed(1, 2)).toBe(9);
+    });
+
+    test('Returns a closure that calls the two functions in order, by passing the results of one call into the other', () => {
+        const greet = person => `Hello ${person}.`;
+        const weatherTalk = sentence => `${sentence} It's a lovely day`;
+        const moodTalk = sentence => `${sentence}! How are you doing?`;
+
+        const sayHelloTo = _.flow([greet, weatherTalk, moodTalk]);
+
+        expect(sayHelloTo('Josh')).toBe('Hello Josh. It\'s a lovely day! How are you doing?');
+    });
+});

--- a/higher-order.js
+++ b/higher-order.js
@@ -240,8 +240,22 @@ const _ = {
         return this.reduce(arr, (previous, current) => {
             return previous || callback(current);
         }, false);
-    }
+    },
 
+    /**
+     * Given an array of functions, returns a function that composes them by successively 
+     * calling each one and passing the result of the previous to the next.
+     * @param {Array} arr - the array containing the functions to be composed.
+     */
+    flow: function(arr) {
+        guardArray(arr);
+
+        return function() {
+            return this.reduce(arr, (previous, current) => {
+                return current(previous);
+            }, arr.shift().apply(this, arguments));
+        }.bind(this);
+    }
 }
 
 module.exports = { _ };


### PR DESCRIPTION
Adds `_.flow` to the library, which composes the passed functions in an array, by calling the result of calling the first to the next and so on.

Example usage: 
```javascript
const add = (a, b) => a + b;
const square = n => n * n;
_.flow([add, square])(); // 9
```